### PR TITLE
Support 1.21.8 with stonecutter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -36,6 +36,6 @@ body:
   - type: "textarea"
     attributes:
       label: "Logs or Crash Report"
-      description: "Provide a link to a log file or crash report. This will help the developers to identify the problematic code. Use a service like https://mclo.gs/, https://gist.github.com"
+      description: "Provide a link to a log file or crash report. You must provide a latest.log, debug.log, and a crash report unless not applicable. You must use a service like https://mclo.gs/, https://gist.github.com rather than pasting the logs directly into the issue."
     validations:
       required: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "java.configuration.updateBuildConfiguration": "interactive"
+    "java.configuration.updateBuildConfiguration": "interactive",
+    "java.compile.nullAnalysis.mode": "disabled"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'dev.architectury.loom' version '1.9-SNAPSHOT'
+    id 'dev.architectury.loom' version '1.13-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 loom.platform = neoforge
 
 # Mod properties
-mod_version = 2.0.0
+mod_version = 2.0.2
 maven_group = me.ajh123.be_quiet_negotiator
 archives_name = be_quiet_negotiator
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ stonecutter {
     centralScript = "build.gradle"
 
     create(getRootProject()) {
-        versions "1.21.1", "1.21.2", "1.21.8"
-        vcsVersion = "1.21.2"
+        versions "1.21.1", "1.21.2", "1.21.8", "1.21.11"
+        vcsVersion = "1.21.11"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,6 @@ stonecutter {
 
     create(getRootProject()) {
         versions "1.21.1", "1.21.2", "1.21.8", "1.21.11"
-        vcsVersion = "1.21.11"
+        vcsVersion = "1.21.8"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,6 @@ stonecutter {
 
     create(getRootProject()) {
         versions "1.21.1", "1.21.2", "1.21.8", "1.21.11"
-        vcsVersion = "1.21.8"
+        vcsVersion = "1.21.11"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,7 +20,7 @@ stonecutter {
     centralScript = "build.gradle"
 
     create(getRootProject()) {
-        versions "1.21.1", "1.21.2"
+        versions "1.21.1", "1.21.2", "1.21.8"
         vcsVersion = "1.21.2"
     }
 }

--- a/src/main/java/me/ajh123/be_quiet_negotiator/ClientConfig.java
+++ b/src/main/java/me/ajh123/be_quiet_negotiator/ClientConfig.java
@@ -6,7 +6,12 @@ import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
-@EventBusSubscriber(modid = BeQuietNegotiator.MODID, bus = EventBusSubscriber.Bus.MOD)
+//? if <1.21.7 {
+/*@EventBusSubscriber(modid = BeQuietNegotiator.MODID, bus = EventBusSubscriber.Bus.MOD)
+*///?}
+//? if >=1.21.7 {
+@EventBusSubscriber(modid = BeQuietNegotiator.MODID)
+//?}
 public class ClientConfig
 {
     private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();

--- a/src/main/java/me/ajh123/be_quiet_negotiator/MixinPlugin.java
+++ b/src/main/java/me/ajh123/be_quiet_negotiator/MixinPlugin.java
@@ -26,6 +26,11 @@ public class MixinPlugin implements IMixinConfigPlugin {
             return false;
         }
         //? }
+        //? if >=1.21.7 {
+        if (mixinClassName.equals("me.ajh123.be_quiet_negotiator.mixins.NetworkRegistryMixin")) {
+            return false;
+        }
+        //? }
         return true;
     }
 

--- a/src/main/java/me/ajh123/be_quiet_negotiator/mixins/NetworkRegistryMixin.java
+++ b/src/main/java/me/ajh123/be_quiet_negotiator/mixins/NetworkRegistryMixin.java
@@ -8,7 +8,12 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.common.ClientCommonPacketListener;
 import net.minecraft.network.protocol.configuration.ClientConfigurationPacketListener;
 import net.minecraft.network.protocol.configuration.ServerConfigurationPacketListener;
+//? if <1.21.11 {
 import net.minecraft.resources.ResourceLocation;
+//?}
+//? if >=1.21.11 {
+/*import net.minecraft.resources.Identifier;
+*///?}
 import net.neoforged.fml.config.ConfigTracker;
 //? if <1.21.2 {
 /*import net.neoforged.neoforge.network.configuration.CheckFeatureFlags;
@@ -41,7 +46,7 @@ public class NetworkRegistryMixin {
     }
 
     //? if <1.21.7 {
-    @Inject(
+    /*@Inject(
             method = "initializeOtherConnection(Lnet/minecraft/network/protocol/configuration/ClientConfigurationPacketListener;)V",
             at = @At("HEAD"),
             remap = false,
@@ -67,10 +72,10 @@ public class NetworkRegistryMixin {
             // We are on the client, connected to a vanilla server, make sure we don't have any modded feature flags
             // or bypass custom feature flags if configured to do so.
             //? if <1.21.2 {
-            /*if (!ClientConfig.bypassCustomFeatureFlags() && !CheckFeatureFlags.handleVanillaServerConnection(listener)) {
+            /^if (!ClientConfig.bypassCustomFeatureFlags() && !CheckFeatureFlags.handleVanillaServerConnection(listener)) {
                 return;
             }
-            *///?}
+            ^///?}
             //? if >=1.21.2 {
             if (!ClientConfig.bypassCustomFeatureFlags()) {
                 return; }
@@ -94,8 +99,9 @@ public class NetworkRegistryMixin {
         }
         // Only propagate to super if we are not connected to a vanilla server - done automatically by not returning early.
     }
-    //?}
+    *///?}
 
+//? if <1.21.11 {
     @SuppressWarnings("unchecked")
     private static Map<ConnectionProtocol, Map<ResourceLocation, PayloadRegistration<?>>> getConnectionProtocolMap() {
         Field payloadRegistrationsField = null;
@@ -114,6 +120,27 @@ public class NetworkRegistryMixin {
         }
         return PAYLOAD_REGISTRATIONS;
     }
+    //?}
+    //? if >=1.21.11 {
+    /*@SuppressWarnings("unchecked")
+    private static Map<ConnectionProtocol, Map<Identifier, PayloadRegistration<?>>> getConnectionProtocolMap() {
+        Field payloadRegistrationsField = null;
+        try {
+            payloadRegistrationsField = NetworkRegistry.class.getDeclaredField("PAYLOAD_REGISTRATIONS");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+        payloadRegistrationsField.setAccessible(true);
+
+        Map<ConnectionProtocol, Map<Identifier, PayloadRegistration<?>>> PAYLOAD_REGISTRATIONS = null;
+        try {
+            PAYLOAD_REGISTRATIONS = (Map<ConnectionProtocol, Map<Identifier, PayloadRegistration<?>>>) payloadRegistrationsField.get(null);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+        return PAYLOAD_REGISTRATIONS;
+    }
+    *///?}
 
     @Inject(
             method = "checkPacket(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/protocol/common/ClientCommonPacketListener;)V",

--- a/src/main/java/me/ajh123/be_quiet_negotiator/mixins/NetworkRegistryMixin.java
+++ b/src/main/java/me/ajh123/be_quiet_negotiator/mixins/NetworkRegistryMixin.java
@@ -40,6 +40,7 @@ public class NetworkRegistryMixin {
         BeQuietNegotiator.isConnectedToVanillaServer = false;
     }
 
+    //? if <1.21.7 {
     @Inject(
             method = "initializeOtherConnection(Lnet/minecraft/network/protocol/configuration/ClientConfigurationPacketListener;)V",
             at = @At("HEAD"),
@@ -93,6 +94,7 @@ public class NetworkRegistryMixin {
         }
         // Only propagate to super if we are not connected to a vanilla server - done automatically by not returning early.
     }
+    //?}
 
     @SuppressWarnings("unchecked")
     private static Map<ConnectionProtocol, Map<ResourceLocation, PayloadRegistration<?>>> getConnectionProtocolMap() {

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,4 +1,4 @@
 plugins {
     id "dev.kikugie.stonecutter"
 }
-stonecutter.active("1.21.11")
+stonecutter.active("1.21.8")

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,4 +1,4 @@
 plugins {
     id "dev.kikugie.stonecutter"
 }
-stonecutter.active("1.21.8")
+stonecutter.active("1.21.11")

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,4 +1,4 @@
 plugins {
     id "dev.kikugie.stonecutter"
 }
-stonecutter.active "1.21.2"
+stonecutter.active("1.21.8")

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,0 +1,9 @@
+deps_java_version = 21
+
+# Minecraft properties
+deps_minecraft_version = 1.21.11
+deps_minecraft_supported_range = [1.21.11]
+
+# Dependencies
+deps_neoforge_version = 21.11.38-beta
+deps_neoforge_supported_range = [21.11.1-beta,)

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,0 +1,9 @@
+deps_java_version = 21
+
+# Minecraft properties
+deps_minecraft_version = 1.21.8
+deps_minecraft_supported_range = [1.21.8,)
+
+# Dependencies
+deps_neoforge_version = 21.8.52
+deps_neoforge_supported_range = [21.8.0-beta,)


### PR DESCRIPTION
You said that I removed stonecutter but you don't wants to remove it instead. So I try to fix all the compatibility issues with 1.21.7+. Finally, I finish it.

Details:
Add 1.21.8 support

- Add Stonecutter conditional compilation for NetworkRegistryMixin
  - Wrap initializeOtherConnection injection with `//? if <1.21.7` condition
  - Method was removed in NeoForge 1.21.7+

- Update MixinPlugin to disable NetworkRegistryMixin on 1.21.7+
  - Prevents runtime conflicts with NeoForge's internal changes

- Build successfully generates mod jar for Minecraft 1.21.8 with NeoForge 21.8.52
